### PR TITLE
Add missing platform check for compiling on OS X / macOS

### DIFF
--- a/include/platformstl/platformstl.h
+++ b/include/platformstl/platformstl.h
@@ -155,7 +155,8 @@
 #if defined(unix) || \
     defined(UNIX) || \
     defined(__unix__) || \
-    defined(__unix)
+    defined(__unix) || \
+    defined(__MACH__)
 # define PLATFORMSTL_OS_IS_UNIX
 #elif defined(WIN64) || \
       defined(_WIN64) || \


### PR DESCRIPTION
OS X / macOS works as a UNIX platform just fine, STLSoft just needs to be told it is one.