### PR TITLE
add ARM architecture for Android NDK GCC compilation

### DIFF
--- a/include/stlsoft/internal/cccap/gcc.h
+++ b/include/stlsoft/internal/cccap/gcc.h
@@ -463,7 +463,8 @@
       defined(__ppc__) || \
       defined(_ARCH_PPC) || \
       defined(__PPC__) || \
-      defined(__powerpc__)
+      defined(__powerpc__) || \
+      defined(__arm__)
  /* LLP64 */
 # define _STLSOFT_SIZEOF_SHORT          (2)
 # define _STLSOFT_SIZEOF_INT            (4)


### PR DESCRIPTION
Add support for the ARM architecture when doing Android NDK GCC compilation.